### PR TITLE
Move test SSH keys configuration to tests section

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -58,10 +58,10 @@ jobs:
           helm lint helm/ssh-workspace \
             --set user.name="testuser" \
             --set "ssh.publicKeys[0]=$(cat /tmp/test_ssh_key.pub)" \
-            --set ssh.testKeys.enabled=true \
+            --set tests.testKeys.enabled=true \
             --set tests.sshConnectivity.enabled=true \
-            --set "ssh.testKeys.keyPairs[0].publicKey=$(cat /tmp/test_ssh_key.pub)" \
-            --set "ssh.testKeys.keyPairs[0].privateKey=$(cat /tmp/test_ssh_key)" \
+            --set "tests.testKeys.keyPairs[0].publicKey=$(cat /tmp/test_ssh_key.pub)" \
+            --set "tests.testKeys.keyPairs[0].privateKey=$(cat /tmp/test_ssh_key)" \
             --debug
 
       - name: Set up Docker Buildx
@@ -217,10 +217,10 @@ jobs:
           ssh:
             publicKeys:
               - $TEST_SSH_PUBLIC_KEY
+          tests:
             testKeys:
               enabled: true
               existingSecret: test-ssh-keys-external
-          tests:
             sshConnectivity:
               enabled: true
             workspaceFunctionality:
@@ -244,13 +244,13 @@ jobs:
           ssh:
             publicKeys:
               - $TEST_SSH_PUBLIC_KEY
+          tests:
             testKeys:
               enabled: true
               keyPairs:
                 - publicKey: $TEST_SSH_PUBLIC_KEY
                   privateKey: |
           $(sed 's/^/          /' $TEST_SSH_PRIVATE_KEY_PATH)
-          tests:
             sshConnectivity:
               enabled: true
             workspaceFunctionality:

--- a/helm/ssh-workspace/templates/configmap.yaml
+++ b/helm/ssh-workspace/templates/configmap.yaml
@@ -16,8 +16,8 @@ data:
 {{- range .Values.ssh.publicKeys }}
     {{ . }}
 {{- end }}
-{{- if .Values.ssh.testKeys.enabled }}
-{{- range .Values.ssh.testKeys.keyPairs }}
+{{- if .Values.tests.testKeys.enabled }}
+{{- range .Values.tests.testKeys.keyPairs }}
     {{ .publicKey }}
 {{- end }}
 {{- end }}

--- a/helm/ssh-workspace/templates/deployment.yaml
+++ b/helm/ssh-workspace/templates/deployment.yaml
@@ -88,8 +88,8 @@ spec:
                 {{- range .Values.ssh.publicKeys }}
                 {{ . }}
                 {{- end }}
-                {{- if .Values.ssh.testKeys.enabled }}
-                {{- range .Values.ssh.testKeys.keyPairs }}
+                {{- if .Values.tests.testKeys.enabled }}
+                {{- range .Values.tests.testKeys.keyPairs }}
                 {{ .publicKey }}
                 {{- end }}
                 {{- end }}

--- a/helm/ssh-workspace/templates/tests/ssh-authentication-test.yaml
+++ b/helm/ssh-workspace/templates/tests/ssh-authentication-test.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.tests.sshConnectivity.enabled .Values.ssh.testKeys.enabled }}
+{{- if and .Values.tests.sshConnectivity.enabled .Values.tests.testKeys.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -202,6 +202,6 @@ spec:
   volumes:
   - name: test-ssh-keys
     secret:
-      secretName: {{ if .Values.ssh.testKeys.existingSecret }}{{ .Values.ssh.testKeys.existingSecret }}{{ else }}{{ include "ssh-workspace.fullname" . }}-test-ssh-keys{{ end }}
+      secretName: {{ if .Values.tests.testKeys.existingSecret }}{{ .Values.tests.testKeys.existingSecret }}{{ else }}{{ include "ssh-workspace.fullname" . }}-test-ssh-keys{{ end }}
       defaultMode: 0600
 {{- end }}

--- a/helm/ssh-workspace/templates/tests/test-ssh-keys-secret.yaml
+++ b/helm/ssh-workspace/templates/tests/test-ssh-keys-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ssh.testKeys.enabled (not .Values.ssh.testKeys.existingSecret) }}
+{{- if and .Values.tests.testKeys.enabled (not .Values.tests.testKeys.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,7 +13,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 type: Opaque
 data:
-  {{- range $index, $keyPair := .Values.ssh.testKeys.keyPairs }}
+  {{- range $index, $keyPair := .Values.tests.testKeys.keyPairs }}
   private-key-{{ $index }}: {{ $keyPair.privateKey | b64enc }}
   public-key-{{ $index }}: {{ $keyPair.publicKey | b64enc }}
   {{- end }}

--- a/helm/ssh-workspace/templates/tests/user-workspace-functionality-test.yaml
+++ b/helm/ssh-workspace/templates/tests/user-workspace-functionality-test.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.tests.workspaceFunctionality.enabled .Values.ssh.testKeys.enabled }}
+{{- if and .Values.tests.workspaceFunctionality.enabled .Values.tests.testKeys.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -389,6 +389,6 @@ spec:
   volumes:
   - name: test-ssh-keys
     secret:
-      secretName: {{ if .Values.ssh.testKeys.existingSecret }}{{ .Values.ssh.testKeys.existingSecret }}{{ else }}{{ include "ssh-workspace.fullname" . }}-test-ssh-keys{{ end }}
+      secretName: {{ if .Values.tests.testKeys.existingSecret }}{{ .Values.tests.testKeys.existingSecret }}{{ else }}{{ include "ssh-workspace.fullname" . }}-test-ssh-keys{{ end }}
       defaultMode: 0600
 {{- end }}

--- a/helm/ssh-workspace/values.yaml
+++ b/helm/ssh-workspace/values.yaml
@@ -22,30 +22,6 @@ ssh:
   # - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHs5e0OWn1ybIZdO1l1S0Z1w4h4h4h4h4h4h4h4h4h4h user@example.com"
   port: 2222  # SSH port
   config: {}  # Additional SSH configuration
-  
-  # Test SSH keys for automated testing (optional)
-  # These keys are added in addition to the main publicKeys for testing purposes
-  testKeys:
-    enabled: false
-    # Method 1: Direct key pairs - both public and private keys needed for testing
-    keyPairs: []
-    # Example:
-    # keyPairs:
-    #   - publicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGrShAQgt+9ZuPDQ1L2KrSwKxL8BEcqhytt7X3ZLZxai test-key@helm-test"
-    #     privateKey: |
-    #       -----BEGIN OPENSSH PRIVATE KEY-----
-    #       b3BlbnNzaC1QlkeXktZZlnBUKmhp4AAAAC1lZQI5NTE5AAAAIGrShAQgt+9ZuPDQ1L2K
-    #       rSwKxL8BEcqhytt7X3ZLZxaiAAAAFHRlc3Qta2V5QGhlbG0tdGVzdA==
-    #       -----END OPENSSH PRIVATE KEY-----
-    # Method 2: Existing Secret reference (recommended for production)
-    existingSecret: ""  # Name of existing Secret containing test SSH keys
-    # When existingSecret is specified, keyPairs is ignored
-    # Expected Secret format:
-    # data:
-    #   public-key-0: <base64-encoded-public-key>
-    #   private-key-0: <base64-encoded-private-key>
-    #   public-key-1: <base64-encoded-public-key>  # Additional key pairs
-    #   private-key-1: <base64-encoded-private-key>
 
 # Persistence configuration
 persistence:
@@ -126,12 +102,36 @@ tests:
   sshValidation:
     enabled: true  # Enable SSH internal validation tests (SSH server configuration and permissions)
   
+  # Test SSH keys for automated testing (optional)
+  # These keys are added in addition to the main publicKeys for testing purposes
+  testKeys:
+    enabled: false
+    # Method 1: Direct key pairs - both public and private keys needed for testing
+    keyPairs: []
+    # Example:
+    # keyPairs:
+    #   - publicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGrShAQgt+9ZuPDQ1L2KrSwKxL8BEcqhytt7X3ZLZxai test-key@helm-test"
+    #     privateKey: |
+    #       -----BEGIN OPENSSH PRIVATE KEY-----
+    #       b3BlbnNzaC1QlkeXktZZlnBUKmhp4AAAAC1lZQI5NTE5AAAAIGrShAQgt+9ZuPDQ1L2K
+    #       rSwKxL8BEcqhytt7X3ZLZxaiAAAAFHRlc3Qta2V5QGhlbG0tdGVzdA==
+    #       -----END OPENSSH PRIVATE KEY-----
+    # Method 2: Existing Secret reference (recommended for production)
+    existingSecret: ""  # Name of existing Secret containing test SSH keys
+    # When existingSecret is specified, keyPairs is ignored
+    # Expected Secret format:
+    # data:
+    #   public-key-0: <base64-encoded-public-key>
+    #   private-key-0: <base64-encoded-private-key>
+    #   public-key-1: <base64-encoded-public-key>  # Additional key pairs
+    #   private-key-1: <base64-encoded-private-key>
+  
   # SSH connectivity test configuration
   sshConnectivity:
-    enabled: false  # Enable SSH connectivity tests (requires ssh.testKeys.enabled: true)
+    enabled: false  # Enable SSH connectivity tests (requires tests.testKeys.enabled: true)
   
   # User workspace functionality test configuration
   workspaceFunctionality:
-    enabled: false  # Enable workspace functionality tests (requires ssh.testKeys.enabled: true)
+    enabled: false  # Enable workspace functionality tests (requires tests.testKeys.enabled: true)
     networkTest:
       enabled: false  # Enable external network connectivity tests


### PR DESCRIPTION
## Summary

Relocate `ssh.testKeys` configuration to `tests.testKeys` for better logical organization and clearer separation of test-specific settings from production SSH configuration.

## Changes Made

### Configuration Structure
- **Before**: `ssh.testKeys` (mixed with production SSH settings)
- **After**: `tests.testKeys` (grouped with other test configurations)

### Files Updated
- `values.yaml`: Move testKeys section with all comments and examples
- **Helm Templates** (5 files): Update `.Values.ssh.testKeys` → `.Values.tests.testKeys`
  - `configmap.yaml`
  - `deployment.yaml` 
  - `ssh-authentication-test.yaml`
  - `test-ssh-keys-secret.yaml`
  - `user-workspace-functionality-test.yaml`
- **GitHub Actions Workflow**: Update values.yaml generation and helm lint commands

### Improved Structure
```yaml
tests:
  testKeys:           # ← Moved here (test-specific)
    enabled: false
    keyPairs: []
    existingSecret: ""
  sshConnectivity:    # ← Related test configs
    enabled: false    # requires tests.testKeys.enabled: true
  workspaceFunctionality:
    enabled: false    # requires tests.testKeys.enabled: true
```

## Benefits

1. **Logical Grouping**: All test-related configurations are now under `tests`
2. **Clear Separation**: Production SSH settings (`ssh.publicKeys`, `ssh.port`) are separate from test settings
3. **Better Documentation**: Dependencies are clearer (e.g., `requires tests.testKeys.enabled: true`)
4. **Consistent Structure**: Follows existing pattern where test configurations are grouped together

## Test Plan

- [ ] Verify helm lint passes with new configuration structure
- [ ] Confirm existing workflows continue to work with updated values.yaml generation
- [ ] Validate all test cases (keyPairs and existingSecret methods) function correctly
- [ ] Ensure backward compatibility considerations are documented

This change maintains full functionality while improving configuration organization and clarity.

🤖 Generated with [Claude Code](https://claude.ai/code)