### PR TITLE
Add configurable SSH StrictModes setting

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -86,7 +86,7 @@ jobs:
 
 
   test:
-    name: Test (${{ matrix.security_level }}-${{ matrix.persistence_enabled }}-${{ matrix.test_key_method }})
+    name: Test (${{ matrix.security_level }}-${{ matrix.persistence_enabled }}-${{ matrix.test_key_method }}-${{ matrix.ssh_strict_modes }})
     runs-on: ubuntu-latest
     needs: prepare
     strategy:
@@ -95,12 +95,20 @@ jobs:
         security_level: ["basic", "standard", "high"]
         persistence_enabled: ["false", "true"]
         test_key_method: ["keyPairs", "existingSecret"]
+        ssh_strict_modes: ["true", "false"]
         exclude:
           # Limit existingSecret tests to reduce CI time
           - security_level: "high"
             test_key_method: "existingSecret"
           - persistence_enabled: "true"
             test_key_method: "existingSecret"
+          # Limit strict modes tests to reduce CI time - test with basic security and keyPairs only
+          - security_level: "standard"
+            ssh_strict_modes: "true"
+          - security_level: "high"
+            ssh_strict_modes: "true"
+          - test_key_method: "existingSecret"
+            ssh_strict_modes: "true"
           
       fail-fast: false
     steps:
@@ -217,6 +225,7 @@ jobs:
           ssh:
             publicKeys:
               - $TEST_SSH_PUBLIC_KEY
+            strictModes: ${{ matrix.ssh_strict_modes }}
           tests:
             testKeys:
               enabled: true
@@ -244,6 +253,7 @@ jobs:
           ssh:
             publicKeys:
               - $TEST_SSH_PUBLIC_KEY
+            strictModes: ${{ matrix.ssh_strict_modes }}
           tests:
             testKeys:
               enabled: true

--- a/docker/config/sshd_config
+++ b/docker/config/sshd_config
@@ -35,7 +35,7 @@ SyslogFacility AUTH
 LogLevel INFO
 
 # その他セキュリティ設定
-StrictModes yes
+# StrictModes is configured via Helm values (ssh.strictModes)
 IgnoreRhosts yes
 HostbasedAuthentication no
 PermitEmptyPasswords no

--- a/docker/scripts/init-container.sh
+++ b/docker/scripts/init-container.sh
@@ -80,6 +80,7 @@ useradd -u "$SSH_USER_UID" -g "$SSH_USER_GID" -s "$SSH_USER_SHELL" -M "$SSH_USER
 # (This handles both empty and pre-existing volumes)
 mkdir -p "/home/$SSH_USER"
 chown "$SSH_USER:$SSH_USER" "/home/$SSH_USER"
+chmod 755 "/home/$SSH_USER"  # Remove SetGID bit and set proper permissions
 echo "✓ Home directory prepared for $SSH_USER"
 
 # Handle additional groups

--- a/helm/ssh-workspace/templates/configmap.yaml
+++ b/helm/ssh-workspace/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
 {{- end }}
 {{- end }}
 ---
-{{- if .Values.ssh.config }}
+{{- if or .Values.ssh.config (not (eq .Values.ssh.strictModes nil)) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -37,6 +37,9 @@ metadata:
     {{- end }}
 data:
   custom_config: |
+{{- if not (eq .Values.ssh.strictModes nil) }}
+    StrictModes {{ if .Values.ssh.strictModes }}yes{{ else }}no{{ end }}
+{{- end }}
 {{- range $key, $value := .Values.ssh.config }}
     {{ $key }} {{ $value }}
 {{- end }}

--- a/helm/ssh-workspace/values.schema.json
+++ b/helm/ssh-workspace/values.schema.json
@@ -93,6 +93,10 @@
           "maximum": 65535,
           "description": "SSH port"
         },
+        "strictModes": {
+          "type": "boolean",
+          "description": "SSH StrictModes setting (true for strict permission checks, false for relaxed)"
+        },
         "config": {
           "type": "object",
           "description": "Additional SSH configuration"

--- a/helm/ssh-workspace/values.yaml
+++ b/helm/ssh-workspace/values.yaml
@@ -21,6 +21,7 @@ ssh:
   # Example:
   # - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHs5e0OWn1ybIZdO1l1S0Z1w4h4h4h4h4h4h4h4h4h4h user@example.com"
   port: 2222  # SSH port
+  strictModes: true  # SSH StrictModes setting (true for strict permission checks, false for relaxed)
   config: {}  # Additional SSH configuration
 
 # Persistence configuration


### PR DESCRIPTION
## Summary
- Add `ssh.strictModes` configuration option to values.yaml (default: true)
- Enable dynamic SSH configuration generation based on Helm values
- Enhance test coverage with StrictModes variants in CI

## Changes
### Configuration
- **values.yaml**: Add `ssh.strictModes: true` setting with clear documentation
- **values.schema.json**: Add boolean validation for strictModes setting
- **ConfigMap template**: Generate dynamic SSH configuration based on values

### SSH Configuration
- **sshd_config**: Remove hardcoded `StrictModes yes` to enable dynamic configuration
- **ConfigMap**: Auto-generate `StrictModes yes/no` based on `ssh.strictModes` value
- **Backwards compatibility**: Existing `ssh.config` overrides still work

### Permission Fixes
- **init-container.sh**: Add explicit `chmod 755` to prevent SetGID bit issues
- **Home directory ownership**: Ensure proper ownership and permissions

### Testing
- **GitHub Actions**: Add `ssh_strict_modes: ["true", "false"]` to test matrix
- **Comprehensive coverage**: Test both strict and relaxed modes
- **Optimized CI time**: Strategic exclusions to balance coverage and speed

## Use Cases
### StrictModes: true (default)
- **Security-focused deployments**
- **Standard Kubernetes environments**
- **ReadWriteOnce volumes**

### StrictModes: false
- **ReadWriteMany volume environments**
- **Legacy permission setups**
- **Development/testing scenarios**

## Testing
- [x] Helm template validation with both true/false values
- [x] Schema validation for boolean type
- [x] CI matrix includes StrictModes variants
- [x] Backwards compatibility with existing configurations

## Example Usage
```yaml
# Secure mode (default)
ssh:
  strictModes: true

# Relaxed mode for RWX volumes
ssh:
  strictModes: false
```

🤖 Generated with [Claude Code](https://claude.ai/code)