### PR TITLE
Fix GitHub Release assets upload by downloading helm-chart artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,12 @@ jobs:
         with:
           version: ${{ env.HELM_VERSION }}
 
+      - name: Download Helm package artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: helm-chart
+          path: dist/
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Fixes the release workflow failure where GitHub Release assets upload fails with ENOENT error.

## Problem
The publish job was trying to upload  but the file didn't exist because the  command was only run in a different job.

## Solution
Add a step to download the helm-chart artifact before attempting to upload it as a GitHub Release asset.

## Changes
- Add  step to download helm-chart artifact to  directory

This resolves the v0.7.0 release workflow failure.