### PR TITLE
Fix Helm image tag to v0.7.4

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/kaznak/ssh-workspace
   pullPolicy: Always  # Default for production, overridden locally
-  tag: "v0.7.3"
+  tag: "v0.7.4"
 
 # Image pull secrets
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Fix image tag mismatch between Chart.yaml (v0.7.4) and values.yaml (v0.7.3)
- Ensures v0.7.4 image is correctly deployed when installing Helm chart

## Changes
- Update `helm/values.yaml` image tag from v0.7.3 to v0.7.4

## Test plan
- [x] Verify Chart.yaml and values.yaml version consistency
- [ ] CI pipeline validation
- [ ] Chart template generation test

🤖 Generated with [Claude Code](https://claude.ai/code)