### PR TITLE
Add ubuntu-standard and utilities, bump to v0.7.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ KUBECTL = kubectl $(KUBECTL_OPTS)
 
 # Default target
 .PHONY: all
-all: docker-build test helm-package
+all: check-version-consistency docker-build test helm-package
 
 # Help target
 .PHONY: help
@@ -73,7 +73,7 @@ docker-build: tmp/.docker-build-sentinel
 
 # Test targets
 .PHONY: test
-test: lint helm-test docker-test
+test: check-version-consistency lint helm-test docker-test
 
 .PHONY: lint
 lint: helm-lint yaml-lint markdown-lint
@@ -160,7 +160,7 @@ helm-security:
 # Package targets
 
 .PHONY: helm-package
-helm-package: helm-test
+helm-package: helm-test check-version-consistency
 	@echo "Packaging Helm chart..."
 	mkdir -p $(HELM_PACKAGE_DIR)
 	helm package $(HELM_CHART_DIR) --destination $(HELM_PACKAGE_DIR)
@@ -168,7 +168,7 @@ helm-package: helm-test
 
 # Publish targets
 .PHONY: publish
-publish: docker-push helm-publish
+publish: check-version-consistency docker-push helm-publish
 
 .PHONY: docker-push
 docker-push: tmp/.docker-build-sentinel docker-test

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,12 @@ helm-publish: helm-package
 
 # Quality assurance targets
 .PHONY: quality
-quality: lint security
+quality: lint security check-version-consistency
+
+.PHONY: check-version-consistency
+check-version-consistency:
+	@echo "Checking version consistency across project files..."
+	@scripts/check-version-consistency.sh
 
 # Development targets
 

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ help:
 	@echo "  store-host-key-fingerprints       - Store SSH host key fingerprints for verification"
 	@echo "  create-test-file-in-home           - Create test file with passphrase in home directory"
 	@echo "  verify-test-file-persistence       - Verify test file persistence in home directory"
+	@echo "  verify-skeleton-files              - Verify skeleton files (.bashrc, .profile) exist in home directory"
 	@echo "  verify-host-key-secret-persistence   - Verify host key secret persistence"
 	@echo "  verify-host-key-fingerprint-match    - Verify host key fingerprint match after reinstall"
 	@echo ""
@@ -484,6 +485,8 @@ helm-lifecycle-test: docker-build helm-package
 	# [see:V4J1-HOSTKEY] - Verifies SSH host keys are generated during helm release creation
 	$(MAKE) helm-install KUBE_CONTEXT=$(KUBE_CONTEXT) KUBE_NAMESPACE=$(KUBE_NAMESPACE)
 	$(MAKE) helm-status KUBE_CONTEXT=$(KUBE_CONTEXT) KUBE_NAMESPACE=$(KUBE_NAMESPACE)
+	# Verify skeleton files like .bashrc are created in home directory
+	$(MAKE) verify-skeleton-files KUBE_CONTEXT=$(KUBE_CONTEXT) KUBE_NAMESPACE=$(KUBE_NAMESPACE)
 	# [see:W5X2-SECRET] - Stores SSH host key fingerprints for persistence verification
 	$(MAKE) store-host-key-fingerprints KUBE_CONTEXT=$(KUBE_CONTEXT) KUBE_NAMESPACE=$(KUBE_NAMESPACE)
 	# [see:N3M9-PERSIST] - Creates test file to verify home directory persistence
@@ -675,4 +678,35 @@ verify-test-file-persistence:
 		exit 1; \
 	fi
 	@echo "=== Test File Persistence Verification Complete ==="
+
+# Verify skeleton files (like .bashrc) exist in home directory after helm-install
+.PHONY: verify-skeleton-files
+verify-skeleton-files:
+	@echo "=== Verifying Skeleton Files in Home Directory ==="
+	@POD_NAME=$$($(KUBECTL) get pods -l app.kubernetes.io/name=ssh-workspace -o jsonpath='{.items[0].metadata.name}' 2>/dev/null); \
+	if [ -n "$$POD_NAME" ]; then \
+		echo "Pod: $$POD_NAME"; \
+		echo "Checking for skeleton files in /home/developer..."; \
+		MISSING_FILES=""; \
+		for file in .bashrc .profile; do \
+			if $(KUBECTL) exec "$$POD_NAME" -- test -f "/home/developer/$$file" 2>/dev/null; then \
+				echo "✅ Found: /home/developer/$$file"; \
+				echo "Content preview:"; \
+				$(KUBECTL) exec "$$POD_NAME" -- head -n 5 "/home/developer/$$file" | sed 's/^/    /'; \
+			else \
+				echo "❌ Missing: /home/developer/$$file"; \
+				MISSING_FILES="$$MISSING_FILES $$file"; \
+			fi; \
+		done; \
+		if [ -n "$$MISSING_FILES" ]; then \
+			echo "❌ Some skeleton files are missing:$$MISSING_FILES"; \
+			exit 1; \
+		else \
+			echo "✅ All expected skeleton files exist"; \
+		fi; \
+	else \
+		echo "❌ No SSH workspace pod found"; \
+		exit 1; \
+	fi
+	@echo "=== Skeleton Files Verification Complete ==="
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ssh-keygen -t ed25519 -f ~/.ssh/workspace_key -N ""
 2. OCI形式のHelmチャートをインストール
 ```bash
 helm install my-workspace oci://ghcr.io/kaznak/charts/ssh-workspace \
-  --version 0.7.4 \
+  --version 0.7.5 \
   --set ssh.publicKeys.authorizedKeys="$(cat ~/.ssh/workspace_key.pub)"
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ssh-keygen -t ed25519 -f ~/.ssh/workspace_key -N ""
 2. OCI形式のHelmチャートをインストール
 ```bash
 helm install my-workspace oci://ghcr.io/kaznak/charts/ssh-workspace \
-  --version 0.7.1 \
+  --version 0.7.4 \
   --set ssh.publicKeys.authorizedKeys="$(cat ~/.ssh/workspace_key.pub)"
 ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,18 +29,15 @@ FROM ubuntu:22.04
 # Avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install essential packages (without dropbear)
+# Install ubuntu-standard meta-package and additional packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    # Basic development tools [see:Q2N5-TOOLS]
+    ubuntu-standard \
+    # Additional packages not in ubuntu-standard [see:Q2N5-TOOLS]
     git \
     curl \
-    wget \
     vim \
-    nano \
     python3 \
     python3-pip \
-    # For SSH key generation and validation
-    openssh-client \
     # Required for user management
     sudo \
     # Network utilities for health checks
@@ -56,12 +53,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zlib1g \
     # Additional tools for Nix installation script
     tar \
-    xz-utils \
     coreutils \
     openssl \
     # Network and diagnostic tools
     iputils-ping \
-    dnsutils \
     net-tools \
     # Security and authentication
     gnupg \
@@ -72,7 +67,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # File operations
     unzip \
     zip \
-    rsync \
+    # Text viewing and file management
+    less \
+    stow \
+    # Recommended packages from ubuntu-standard that we need
+    nano \
+    openssh-client \
     && rm -rf /var/lib/apt/lists/* \
     && locale-gen en_US.UTF-8
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: ssh-workspace
 description: A Helm chart for secure SSH workspace using Dropbear SSH
 type: application
-version: 0.7.4
-appVersion: "0.7.4"
+version: 0.7.5
+appVersion: "0.7.5"
 home: https://github.com/kaznak/helm-ssh-workspace
 sources:
   - https://github.com/kaznak/helm-ssh-workspace

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/kaznak/ssh-workspace
   pullPolicy: Always  # Default for production, overridden locally
-  tag: "v0.7.4"
+  tag: "v0.7.5"
 
 # Image pull secrets
 imagePullSecrets: []

--- a/scripts/check-version-consistency.sh
+++ b/scripts/check-version-consistency.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# [P3R8-VERSION] バージョン番号整合性チェックスクリプト
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# バージョン番号を抽出する関数
+extract_helm_chart_version() {
+    grep '^version:' "${PROJECT_ROOT}/helm/Chart.yaml" | sed 's/version: *//g'
+}
+
+extract_helm_app_version() {
+    grep '^appVersion:' "${PROJECT_ROOT}/helm/Chart.yaml" | sed 's/appVersion: *"*//g' | sed 's/"*$//g'
+}
+
+extract_helm_image_tag() {
+    grep '  tag:' "${PROJECT_ROOT}/helm/values.yaml" | sed 's/.*tag: *"*//g' | sed 's/"*$//g' | sed 's/^v//g'
+}
+
+extract_readme_version() {
+    grep -- '--version' "${PROJECT_ROOT}/README.md" | sed 's/.*--version *//g' | sed 's/ .*//g'
+}
+
+# メイン処理
+main() {
+    echo "=== バージョン番号整合性チェック ==="
+    
+    local helm_chart_version helm_app_version helm_image_tag readme_version
+    local exit_code=0
+    
+    helm_chart_version=$(extract_helm_chart_version)
+    helm_app_version=$(extract_helm_app_version)
+    helm_image_tag=$(extract_helm_image_tag)
+    readme_version=$(extract_readme_version)
+    
+    echo "Helm Chart version: ${helm_chart_version}"
+    echo "Helm App version: ${helm_app_version}"
+    echo "Helm image tag: ${helm_image_tag}"
+    echo "README version: ${readme_version}"
+    echo
+    
+    # バージョン整合性チェック
+    if [[ "${helm_chart_version}" != "${helm_app_version}" ]]; then
+        echo "❌ ERROR: Helm Chart version (${helm_chart_version}) != App version (${helm_app_version})"
+        exit_code=1
+    fi
+    
+    if [[ "${helm_app_version}" != "${helm_image_tag}" ]]; then
+        echo "❌ ERROR: Helm App version (${helm_app_version}) != Image tag (${helm_image_tag})"
+        exit_code=1
+    fi
+    
+    if [[ "${helm_app_version}" != "${readme_version}" ]]; then
+        echo "❌ ERROR: Helm App version (${helm_app_version}) != README version (${readme_version})"
+        exit_code=1
+    fi
+    
+    if [[ ${exit_code} -eq 0 ]]; then
+        echo "✅ すべてのバージョン番号が一致しています"
+    fi
+    
+    exit ${exit_code}
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Add ubuntu-standard meta-package for complete command-line environment
- Add less and stow utilities
- Improve skeleton file verification test
- Bump version to 0.7.5

## Changes

### Docker Image Improvements
- Added `ubuntu-standard` meta-package to provide standard Unix command-line tools
- Removed redundant packages already included in ubuntu-standard (wget, rsync, xz-utils, dnsutils)
- Added `less` for text viewing and `stow` for dotfile management
- Explicitly included `nano` and `openssh-client` due to --no-install-recommends flag

### Testing Improvements
- Added `verify-skeleton-files` target to verify .bashrc and .profile creation
- Integrated skeleton file verification into helm-lifecycle-test
- Added version consistency checks to build pipeline

### Version Updates
- Bumped version from 0.7.4 to 0.7.5 across all files
- Ensured version consistency in Chart.yaml, values.yaml, and README.md

## Test plan
- [ ] Build Docker image successfully
- [ ] Run `make helm-lifecycle-test` to verify skeleton files
- [ ] Verify ubuntu-standard tools are available in container
- [ ] Test SSH connectivity and workspace functionality

🤖 Generated with [Claude Code](https://claude.ai/code)